### PR TITLE
Fix missing undefined in function input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/sdk",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/sdk",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/connections/cloudflare.ts
+++ b/src/connections/cloudflare.ts
@@ -56,7 +56,7 @@ export class CloudflareD1Connection implements Connection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query(query: string, parameters: Record<string, any>[] | undefined): Promise<{ data: any, error: Error | null }> {
+    async query(query: string, parameters?: Record<string, any>[]): Promise<{ data: any, error: Error | null }> {
         if (!this.apiKey) throw new Error('Cloudflare API key is not set');
         if (!this.accountId) throw new Error('Cloudflare account ID is not set');
         if (!this.databaseId) throw new Error('Cloudflare database ID is not set');

--- a/src/connections/index.ts
+++ b/src/connections/index.ts
@@ -1,5 +1,5 @@
 export interface Connection {
     connect: (details: Record<string, any>) => Promise<any>;
     disconnect: () => Promise<any>;
-    query: (query: string, parameters: Record<string, any>[] | undefined) => Promise<{ data: any, error: Error | null }>;
+    query: (query: string, parameters?: Record<string, any>[]) => Promise<{ data: any, error: Error | null }>;
 }

--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -52,7 +52,7 @@ export class OuterbaseConnection implements Connection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query(query: string, parameters: Record<string, any>[]): Promise<{ data: any, error: Error | null }> {
+    async query(query: string, parameters: Record<string, any>[] | undefined): Promise<{ data: any, error: Error | null }> {
         if (!this.api_key) throw new Error('Outerbase API key is not set');
         if (!query) throw new Error('Query was not provided');
 

--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -52,7 +52,7 @@ export class OuterbaseConnection implements Connection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query(query: string, parameters: Record<string, any>[] | undefined): Promise<{ data: any, error: Error | null }> {
+    async query(query: string, parameters?: Record<string, any>[]): Promise<{ data: any, error: Error | null }> {
         if (!this.api_key) throw new Error('Outerbase API key is not set');
         if (!query) throw new Error('Query was not provided');
 


### PR DESCRIPTION
The outerbase.ts `query` function did not fully adhere to the Typescript definition. Making the second argument in the `query(...)` function an optional.