### PR TITLE
Remove Process for Cloudflare Worker

### DIFF
--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -1,5 +1,5 @@
 import { Connection } from './index';
-export const API_URL = process.env.OUTERBASE_API_URL ?? 'https://app.outerbase.com'
+export const API_URL = 'https://app.outerbase.com'
 
 export class OuterbaseConnection implements Connection {
     // The API key used for Outerbase authentication


### PR DESCRIPTION
Cloudflare workers do not give libraries the ability to use `process` at all. By removing this, we can use this library with Cloudflare Workers.