### PR TITLE
Remove connect() arguments

### DIFF
--- a/src/connections/cloudflare.ts
+++ b/src/connections/cloudflare.ts
@@ -26,7 +26,7 @@ export class CloudflareD1Connection implements Connection {
      * @param details - Unused in the Cloudflare scenario.
      * @returns Promise<any>
      */
-    async connect(details: Record<string, any>): Promise<any> {
+    async connect(): Promise<any> {
         return Promise.resolve();
     }
 

--- a/src/connections/index.ts
+++ b/src/connections/index.ts
@@ -1,5 +1,5 @@
 export interface Connection {
-    connect: (details: Record<string, any>) => Promise<any>;
+    connect: () => Promise<any>;
     disconnect: () => Promise<any>;
     query: (query: string, parameters?: Record<string, any>[]) => Promise<{ data: any, error: Error | null }>;
 }

--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -22,7 +22,7 @@ export class OuterbaseConnection implements Connection {
      * @param details - Unused in the Outerbase scenario.
      * @returns Promise<any>
      */
-    async connect(details: Record<string, any>): Promise<any> {
+    async connect(): Promise<any> {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
This PR removes the arguments in a `Connect` classes `connect()` function. All of the required parameters to connect to a database are suggested at this time to be done via the constructor function.

Resolves #17 