### PR TITLE
Connection constructor named object

### DIFF
--- a/playground/index.js
+++ b/playground/index.js
@@ -5,11 +5,11 @@ const app = express();
 const port = 4000;
 
 app.get('/', async (req, res) => {
-    const d1 = new CloudflareD1Connection(
-        'API_KEY',
-        'ACCOUNT_ID',
-        'DATABASE_ID'
-    );
+    const d1 = new CloudflareD1Connection({
+        apiKey: 'API_KEY',
+        accountId: 'ACCOUNT_ID',
+        databaseId: 'DATABASE_ID'
+    })
     const db = Outerbase(d1);
     
     // SELECT:

--- a/src/connections/cloudflare.ts
+++ b/src/connections/cloudflare.ts
@@ -1,5 +1,11 @@
 import { Connection } from './index';
 
+export type CloudflareD1ConnectionDetails = {
+    apiKey: string,
+    accountId: string,
+    databaseId: string
+};
+
 export class CloudflareD1Connection implements Connection {
     // The Cloudflare API key with D1 access
     apiKey: string | undefined;
@@ -11,11 +17,13 @@ export class CloudflareD1Connection implements Connection {
      * account ID, and database ID.
      * 
      * @param apiKey - The API key to be used for authentication.
+     * @param accountId - The account ID to be used for authentication.
+     * @param databaseId - The database ID to be used for querying.
      */
-    constructor(apiKey: string, accountId: string, databaseId: string) {
-        this.apiKey = apiKey;
-        this.accountId = accountId;
-        this.databaseId = databaseId;
+    constructor(private _: CloudflareD1ConnectionDetails) {
+        this.apiKey = _.apiKey;
+        this.accountId = _.accountId;
+        this.databaseId = _.databaseId;
     }
 
     /**

--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -1,6 +1,10 @@
 import { Connection } from './index';
 export const API_URL = 'https://app.outerbase.com'
 
+export type OuterbaseConnectionDetails = {
+    apiKey: string
+};
+
 export class OuterbaseConnection implements Connection {
     // The API key used for Outerbase authentication
     api_key: string | undefined;
@@ -10,8 +14,10 @@ export class OuterbaseConnection implements Connection {
      * 
      * @param apiKey - The API key to be used for authentication.
      */
-    constructor(private apiKey: string) {
-        this.api_key = apiKey;
+    constructor(private _: {
+        apiKey: string
+    }) {
+        this.api_key = _.apiKey;
     }
 
     /**

--- a/tests/connections/cloudflare.test.ts
+++ b/tests/connections/cloudflare.test.ts
@@ -5,11 +5,11 @@ import { QueryType } from 'src/query-params'
 
 describe('CloudflareD1Connection', () => {
     describe('Query Type', () => {
-        const connection = new CloudflareD1Connection(
-            'API_KEY',
-            'ACCOUNT_ID',
-            'DATABASE_ID'
-        )
+        const connection = new CloudflareD1Connection({
+            apiKey: 'API_KEY',
+            accountId: 'ACCOUNT_ID',
+            databaseId: 'DATABASE_ID'
+        })
 
         test('Query type is set to positional', () => {
             expect(connection.queryType).toBe(QueryType.positional)

--- a/tests/connections/outerbase.test.ts
+++ b/tests/connections/outerbase.test.ts
@@ -5,7 +5,9 @@ import { QueryType } from 'src/query-params'
 
 describe('OuterbaseConnection', () => {
     describe('Query Type', () => {
-        const connection = new OuterbaseConnection('FAKE_API_KEY')
+        const connection = new OuterbaseConnection({
+            apiKey: 'FAKE_API_KEY'
+        })
 
         test('Query type is set to named', () => {
             expect(connection.queryType).toBe(QueryType.named)

--- a/tests/to-string.test.ts
+++ b/tests/to-string.test.ts
@@ -5,7 +5,9 @@ import { Outerbase, equals, equalsNumber } from 'src/index'
 
 describe('toString', () => {
     describe('SELECT statements', () => {
-        const connection = new OuterbaseConnection('FAKE_API_KEY')
+        const connection = new OuterbaseConnection({
+            apiKey: 'FAKE_API_KEY'
+        })
         const db = Outerbase(connection)
 
         test('Select from one table, one column', () => {
@@ -62,7 +64,9 @@ describe('toString', () => {
     })
 
     describe('queryBuilder - Reserved keywords get quotes', () => {
-        const connection = new OuterbaseConnection('FAKE_API_KEY')
+        const connection = new OuterbaseConnection({
+            apiKey: 'FAKE_API_KEY'
+        })
         const db = Outerbase(connection)
 
         test('toString – Not reserved keyword "users" is not wrapped in quotes', () => {


### PR DESCRIPTION
## Purpose
Previously for classes that implemented `Connection` interface, each `constructor` could have it's own custom arguments needed to fulfill it's classes usage. When you list out the arguments when constructing a new instance of it you would have to know what argument goes in what order, and the arguments differ per Connection class.

This change makes it so each Connection constructor now takes an object that has a type associated to it so you can see what the values required are.

Resolves #10 

## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Update the `OuterbaseConnection` constructor to support a `OuterbaseConnectionDetails` type in the constructor
- [X] Update the `CloudflareD1Connection` constructor to support a `CloudflareD1ConnectionDetails` type in the constructor

## Verify
<!-- guidance or steps to assist the reviewer -->

- You can still instantiate and query a Cloudflare connection
- You can still instantiate and query an Outerbase connection

## Before
<!-- screenshot before changes -->
```ts
const d1 = new CloudflareD1Connection(
    'API_KEY',
    'ACCOUNT_ID',
    'DATABASE_ID'
)
```


## After
<!-- screenshot after changes -->
```ts
const d1 = new CloudflareD1Connection({
    apiKey: 'API_KEY',
    accountId: 'ACCOUNT_ID',
    databaseId: 'DATABASE_ID'
})
```