### PR TITLE
Attach connections and actions to models

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -55,8 +55,17 @@ export function Outerbase(connection: Connection): OuterbaseType {
         return this;
     },
     where(condition) {
-        if (this.queryBuilder.whereClauses)
-            this.queryBuilder.whereClauses.push(condition);
+        // Check if `condition` is an array of conditions
+        if (Array.isArray(condition)) {
+            if (this.queryBuilder.whereClauses) {
+                this.queryBuilder.whereClauses.push(`(${condition.join(" AND ")})`);
+            }
+        } else {
+            if (this.queryBuilder.whereClauses) {
+                this.queryBuilder.whereClauses.push(condition);
+            }
+        }
+        
         return this;
     },
     limit(limit) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -407,14 +407,13 @@ function buildQueryString(
 
 function mapToClass<T>(data: any | any[], ctor: new (data: any) => T, connection?: Connection): T | T[] {
     if (Array.isArray(data)) {
-        let array = data.map((item) => {
-            let model = new ctor(item) as BaseTable
-            model._connection = connection
-            return model
-        })
-        return array as T[]
+        return data.map(item => {
+            const model = new ctor(item) as BaseTable;
+            model._connection = connection;
+            return model;
+        }) as T[];
     } else {
-        let model = new ctor(data) as BaseTable
+        const model = new ctor(data) as BaseTable
         model._connection = connection
         return new ctor(data)
     }

--- a/src/generators/model-template.handlebars
+++ b/src/generators/model-template.handlebars
@@ -13,7 +13,8 @@ export class {{ capitalize (camelCase name) }} extends BaseTable {
     constructor(data: any) {
         super({
             _name: "{{name}}",
-            _schema: "{{schema}}"
+            _schema: "{{schema}}",
+            _original: data
         });
 
         {{#each columns}}

--- a/src/models/decorators.ts
+++ b/src/models/decorators.ts
@@ -66,10 +66,26 @@ export function isColumnNullable(targetClass: Function, propertyName: string): b
     return false;
 }
 
-export function getPrimaryKey(targetClass: Function): string | symbol | undefined {
+export function getPrimaryKeys(targetClass: Function): string[] {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata) {
-        return metadata.primaryKey;
+        // Get all the keys of the metadata object that are primary keys
+        const keys = Object.keys(metadata.columns).filter((key) => metadata.columns[key].primary);
+
+        // Return the actual column name as it is stored in the database
+        return keys.map((key) => metadata.columns[key].name);
     }
-    return undefined;
+    return [];
+}
+
+export function getColumnValueFromName(targetClass: Function, columnName: string): string {
+    const metadata = metadataRegistry.get(targetClass);
+    if (metadata) {
+        for (const key in metadata.columns) {
+            if (metadata.columns[key].name === columnName) {
+                return key;
+            }
+        }
+    }
+    return '';
 }

--- a/src/models/decorators.ts
+++ b/src/models/decorators.ts
@@ -4,6 +4,7 @@
  * the value is an object with the following properties:
  * - columns: an object where the keys are property keys and the values are objects with column options
  * - primaryKey: the property key of the primary key column
+ * 
  * @type {Map<Function, any>}
  */
 export const metadataRegistry = new Map<Function, any>();
@@ -81,6 +82,7 @@ export function getPrimaryKeys(targetClass: Function): string[] {
 /**
  * Based on the column name value, however it is stored in the database, get the actual
  * key name of the property in the class.
+ * 
  * @param targetClass 
  * @param columnName 
  * @returns String – the property name
@@ -100,6 +102,7 @@ export function getColumnValueFromName(targetClass: Function, columnName: string
 /**
  * Based on the actual property name, usually camel cased, get the column name value
  * that is stored in the database.
+ * 
  * @param targetClass 
  * @param propertyName 
  * @returns String – the column name

--- a/src/models/decorators.ts
+++ b/src/models/decorators.ts
@@ -78,6 +78,13 @@ export function getPrimaryKeys(targetClass: Function): string[] {
     return [];
 }
 
+/**
+ * Based on the column name value, however it is stored in the database, get the actual
+ * key name of the property in the class.
+ * @param targetClass 
+ * @param columnName 
+ * @returns String – the property name
+ */
 export function getColumnValueFromName(targetClass: Function, columnName: string): string {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata) {
@@ -86,6 +93,21 @@ export function getColumnValueFromName(targetClass: Function, columnName: string
                 return key;
             }
         }
+    }
+    return '';
+}
+
+/**
+ * Based on the actual property name, usually camel cased, get the column name value
+ * that is stored in the database.
+ * @param targetClass 
+ * @param propertyName 
+ * @returns String – the column name
+ */
+export function getColumnValueFromProperty(targetClass: Function, propertyName: string): string {
+    const metadata = metadataRegistry.get(targetClass);
+    if (metadata) {
+        return metadata.columns[propertyName].name;
     }
     return '';
 }

--- a/src/models/decorators.ts
+++ b/src/models/decorators.ts
@@ -49,16 +49,38 @@ export function Column(options?: {
     };
 }
 
+/**
+ * Indicates that the provided property name is a valid column in the database
+ * for this model class (database table).
+ * 
+ * @param targetClass 
+ * @param propertyName 
+ * @returns Boolean – whether the property is a column
+ */
 export function isColumn(targetClass: Function, propertyName: string): boolean {
     const metadata = metadataRegistry.get(targetClass);
     return metadata && metadata.columns[propertyName];
 }
 
+/**
+ * Indicates whether a column is a unique column in the database.
+ * 
+ * @param targetClass 
+ * @param propertyName 
+ * @returns Boolean – whether the column is a unique column
+ */
 export function isPropertyUnique(targetClass: Function, propertyName: string): boolean {
     const metadata = metadataRegistry.get(targetClass);
     return metadata && metadata[propertyName] && metadata[propertyName].unique
 }
 
+/**
+ * Indicates whether a column can be set as a null value in the database.
+ * 
+ * @param targetClass 
+ * @param propertyName 
+ * @returns Boolean – whether the column can be null
+ */
 export function isColumnNullable(targetClass: Function, propertyName: string): boolean {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata && metadata.columns[propertyName] && metadata.columns[propertyName].hasOwnProperty('nullable')) {
@@ -67,14 +89,22 @@ export function isColumnNullable(targetClass: Function, propertyName: string): b
     return false;
 }
 
+/**
+ * Retrieve the primary key column names for a given model class
+ * based on the metadata stored by the decorators.
+ * 
+ * @param targetClass 
+ * @returns Array of strings – the primary key column names
+ */
 export function getPrimaryKeys(targetClass: Function): string[] {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata) {
-        // Get all the keys of the metadata object that are primary keys
-        const keys = Object.keys(metadata.columns).filter((key) => metadata.columns[key].primary);
-
         // Return the actual column name as it is stored in the database
-        return keys.map((key) => metadata.columns[key].name);
+        const primaryKeyColumnsNames = Object.keys(metadata.columns)
+            .filter((key) => metadata.columns[key].primary)
+            .map((key) => metadata.columns[key].name);
+
+        return primaryKeyColumnsNames;
     }
     return [];
 }
@@ -87,7 +117,7 @@ export function getPrimaryKeys(targetClass: Function): string[] {
  * @param columnName 
  * @returns String – the property name
  */
-export function getColumnValueFromName(targetClass: Function, columnName: string): string {
+export function getColumnValueFromName(targetClass: Function, columnName: string): string | null {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata) {
         for (const key in metadata.columns) {
@@ -96,7 +126,7 @@ export function getColumnValueFromName(targetClass: Function, columnName: string
             }
         }
     }
-    return '';
+    return null;
 }
 
 /**
@@ -107,10 +137,10 @@ export function getColumnValueFromName(targetClass: Function, columnName: string
  * @param propertyName 
  * @returns String – the column name
  */
-export function getColumnValueFromProperty(targetClass: Function, propertyName: string): string {
+export function getColumnValueFromProperty(targetClass: Function, propertyName: string): string | null {
     const metadata = metadataRegistry.get(targetClass);
     if (metadata) {
         return metadata.columns[propertyName].name;
     }
-    return '';
+    return null;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -49,7 +49,10 @@ export class BaseTable {
         }
 
         return primaryKeys.map((key) => {
-            return equals(key, this._original?.[getColumnValueFromName(this.constructor, key)]);
+            const columnValue = getColumnValueFromName(this.constructor, key)
+            if (columnValue === null) return '';
+
+            return equals(key, this._original?.[columnValue]);
         });
     }
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,12 +1,69 @@
+import { OuterbaseType, equals } from "../client";
+import { getColumnValueFromName, getPrimaryKeys } from "./decorators";
+
 export class BaseTable {
     _name: string;
     _schema?: string;
+    _original?: Record<string, any>;
+    _connection?: OuterbaseType;
 
     constructor(_: {
         _name: string,
-        _schema?: string
+        _schema?: string,
+        _original?: Record<string, any>
     }) {
         this._name = _._name;
         this._schema = _._schema;
+        this._original = _._original;
+    }
+
+    attachConnection(connection: OuterbaseType) {
+        this._connection = connection;
+    }
+
+    /**
+     * Fetches the latest version of this model from the database.
+     * When you want to make sure this model represents the latest
+     * version of the data in the database, you can call this method.
+     * 
+     * @returns Promise<any>
+     */
+    async sync(): Promise<void> {
+        if (!this._connection) {
+            throw new Error('Connection not attached');
+        }
+
+        const primaryKeys = getPrimaryKeys(this.constructor);
+
+        if (primaryKeys?.length === 0) {
+            throw new Error('No primary keys found');
+        }
+
+        // Create WHERE clause conditions to find the record based on the available primary keys
+        const conditions = primaryKeys.map((key) => {
+            return equals(key, this._original?.[getColumnValueFromName(this.constructor, key)]);
+        });
+
+        let { data } = await this._connection
+            .selectFrom([
+                { schema: this._schema, table: this._name, columns: ['*'] },
+            ])
+            .where(conditions)
+            .limit(1)
+            // .asClass(T)
+            .query()
+
+        // Set the `data` object to the `_original` property
+        this._original = data;
+
+        return;
+    }
+
+    delete() {
+        if (!this._connection) {
+            throw new Error('Connection not attached');
+        }
+
+        // TODO: Implement the query builder to construct a DELETE query for this row entry
     }
 }


### PR DESCRIPTION
## Purpose


Resolves #4 

## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] `BaseTable` supports an `attachConnection` function for accessing query builder
- [X] Had a need to support multiple `WHERE` clauses in a query chain builder, support arrays
- [X] Store the original `data` object in each model for referencing the primary key values to base changes on
- [X] Change decorator support from `getPrimaryKey(...)` -> `getPrimaryKeys(...)`
- [x] The `mapToClass` function should automatically `attachConnection` to all models
- [x] Implement a `pull()` function in models for getting latest database values and updating model
- [x] Implement an `update()` function in models to automatically update their values in the database
- [x] Implement a `delete()` function in models to automatically delete the row entry from the database
- [x] Implement an `insert()` function in models to automatically create a new row entry with that classes values

**Pending Questions:**
- [x] Should the function name be `sync()` on a model where the model pulls latest values from database and sets its properties to it, or something more explicit to the directionality of the action such as `.pull()`

## Verify
<!-- guidance or steps to assist the reviewer -->

- Need to verify query builder with single `WHERE` clause still operates as intended
- Need to verify query builder with multiple `WHERE` clauses still operate as intended (pass in multiple `.where({})`
- Need to verify query builder with multiple `WHERE` clauses still operate as intended (pass in array)
- Test model can `sync` and self-update values to database values
- Test model can `update` its values to the database
- Test model can `delete` its row from the database
- Test model can `insert` a new row into the database

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->
