### PR TITLE
Delete paths when generating models

### DIFF
--- a/src/generators/generate-models.ts
+++ b/src/generators/generate-models.ts
@@ -61,6 +61,8 @@ async function main() {
         let schemaResponse = json.response
         let tables: Array<any> = []
 
+        const deletedPathsMap: Record<string, any> = {}
+
         for (let key in schemaResponse) {
             let isPublic = key.toLowerCase() === 'public'
 
@@ -204,6 +206,14 @@ async function main() {
                         currentFolderPath,
                         `${table.name}.ts`
                     )
+
+                    // Remove the existing models directory and create a new one if it doesn't exist
+                    // but only if it hasn't been deleted already.
+                    if (!deletedPathsMap[currentFolderPath]) {
+                        await fs.rmdir(currentFolderPath, { recursive: true })
+                        deletedPathsMap[currentFolderPath] = true
+                    }
+                    
                     await fs.mkdir(currentFolderPath, { recursive: true })
                     await fs.writeFile(modelPath, model)
 


### PR DESCRIPTION
## Purpose
Currently when you run the `generate-models` script if you had tables that had previously existed and no longer do, those models would not be deleted on the next run. This approach makes certain that each path we write a model to is at first removed before the path is re-created making is no previous models remain and only current ones are created.

This pull request does NOT resolve if an entire schema was deleted as a sibling to `public` that it will be removed in the folder structure. The current execution of this code would not know that path exists.

Resolves #34 


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Remove previous paths that exist before creating new model files

## Verify
<!-- guidance or steps to assist the reviewer -->

- Run your `sync-models` script
- Delete a table in your database
- Run your `sync-models` script a second time
- See if the previous table model file is removed

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->
