### PR TITLE
Prevent duplicate imports in database model introspection

### DIFF
--- a/src/generators/generate-models.ts
+++ b/src/generators/generate-models.ts
@@ -106,8 +106,8 @@ async function main() {
                                         table.references.some(
                                             (ref: {
                                                 name: string
-                                                table: string
-                                                schema: string
+                                                table: any
+                                                schema: any
                                             }) =>
                                                 ref.name === firstColumn.name &&
                                                 ref.table ===

--- a/src/generators/generate-models.ts
+++ b/src/generators/generate-models.ts
@@ -102,11 +102,26 @@ async function main() {
                                 ) {
                                     const firstColumn = constraint.columns[0]
 
-                                    table.references.push({
-                                        name: firstColumn.name,
-                                        table: firstColumn.table,
-                                        schema: firstColumn.schema,
-                                    })
+                                    const referenceExists =
+                                        table.references.some(
+                                            (ref: {
+                                                name: string
+                                                table: string
+                                                schema: string
+                                            }) =>
+                                                ref.name === firstColumn.name &&
+                                                ref.table ===
+                                                    firstColumn.table &&
+                                                ref.schema ===
+                                                    firstColumn.schema
+                                        )
+                                    if (!referenceExists) {
+                                        table.references.push({
+                                            name: firstColumn.name,
+                                            table: firstColumn.table,
+                                            schema: firstColumn.schema,
+                                        })
+                                    }
                                 }
 
                                 return (


### PR DESCRIPTION
## Purpose
Resolves #27 where when a user uses database model introspection, if multiple columns in one table referenced the same foreign table it would import that relationship class N times.

This PR resolves that issue so each class is only imported once per class.

## Tasks
<!-- [ ] incomplete; [x] complete -->

- [ ] Allow classes to be uniquely imported once

## Verify
<!-- guidance or steps to assist the reviewer -->

- 

## Before
<!-- screenshot before changes -->
![image](https://github.com/outerbase/sdk/assets/113078518/fe7853bb-6807-41f1-959b-ddc9b4711f65)



## After
<!-- screenshot after changes -->
![image](https://github.com/outerbase/sdk/assets/113078518/ac28ffb8-accd-447b-aac5-1fe695c56f57)
