### PR TITLE
Connection Factory

### DIFF
--- a/playground/index.js
+++ b/playground/index.js
@@ -1,4 +1,4 @@
-import { CloudflareD1Connection, Outerbase, OuterbaseConnection, equalsNumber } from '../dist/index.js';
+import { DatabaseFactory, DatabaseType, Outerbase, greaterThanOrEqualNumber } from '../dist/index.js';
 import express from 'express';
 
 const app = express();

--- a/src/connections/_factory.ts
+++ b/src/connections/_factory.ts
@@ -1,0 +1,26 @@
+// DatabaseFactory.ts
+import { Connection } from './index'
+
+export enum DatabaseType {
+    Outerbase = 'outerbase',
+    Cloudflare = 'cloudflare',
+    Neon = 'neon'
+}
+
+export class DatabaseFactory {
+    static async createConnection(type: DatabaseType, config: any): Promise<Connection> {
+        switch (type) {
+            case DatabaseType.Outerbase:
+                const { OuterbaseConnection } = await import('./outerbase');
+                return new OuterbaseConnection(config);
+            case DatabaseType.Cloudflare:
+                const { CloudflareD1Connection } = await import('./cloudflare');
+                return new CloudflareD1Connection(config);
+            case DatabaseType.Neon:
+                // const { MySQLConnection } = await import('./MySQLConnection');
+                // return new MySQLConnection(config);
+            default:
+                throw new Error(`Unsupported database type: ${type}`);
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './connections';
+export * from './connections/_factory';
 export * from './connections/outerbase';
-export * from './connections/cloudflare';
+// export * from './connections/cloudflare';
 export * from './client';
 export * from './models';
 export * from './models/decorators';


### PR DESCRIPTION
## Purpose
Currently the way the project is structured, each time we add support for a new connection type it requires the NPM packages to be included for all of them. Our goal is if a user comes to use our SDK and is only seeking to use, say Neon, then we only should require the installation of the Neon serverless driver via NPM.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Make a factory class
- [X] Instantiate Connection classes via the factory

## Verify
<!-- guidance or steps to assist the reviewer -->

- In the playground add the following code to query via an Outerbase connection

```
const connection = await DatabaseFactory.createConnection(DatabaseType.Outerbase, {
        apiKey: 'INSERT_API_KEY'
    });
    const db = Outerbase(connection);

    const { data, error } = await db
        .selectFrom([{ table: 'users', columns: ['*'] }])
        .limit(10)
        .query()
```

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->
