### PR TITLE
Run isn't a parameter

### DIFF
--- a/src/connections/outerbase.ts
+++ b/src/connections/outerbase.ts
@@ -78,7 +78,6 @@ export class OuterbaseConnection implements Connection {
             body: JSON.stringify({
                 query: query.query,
                 params: query.parameters,
-                run: true,
             }),
         })
 


### PR DESCRIPTION
## Purpose
Recently made a switch to the endpoint where run isn't an acceptable parameter


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [ ] 

## Verify
<!-- guidance or steps to assist the reviewer -->

- 

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->
