### PR TITLE
BigQuery primary key support, binding NULL value and auto casting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@outerbase/sdk",
-    "version": "2.0.0-rc.0",
+    "version": "2.0.0-rc.1",
     "description": "",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/src/connections/bigquery.ts
+++ b/src/connections/bigquery.ts
@@ -153,6 +153,18 @@ export class BigQueryConnection extends SqlConnection {
         );
     }
 
+    async delete(
+        schemaName: string,
+        tableName: string,
+        where: Record<string, unknown>
+    ): Promise<QueryResult> {
+        return super.delete(
+            schemaName,
+            tableName,
+            await this.autoCastingType(schemaName, tableName, where)
+        );
+    }
+
     async select(
         schemaName: string,
         tableName: string,

--- a/src/connections/mysql.ts
+++ b/src/connections/mysql.ts
@@ -155,7 +155,11 @@ export function buildMySQLDatabaseSchmea({
         } as Constraint;
 
         constraintLookup[
-            constraint.TABLE_SCHEMA + '.' + constraint.CONSTRAINT_NAME
+            constraint.TABLE_SCHEMA +
+                '.' +
+                constraint.TABLE_NAME +
+                '.' +
+                constraint.CONSTRAINT_NAME
         ] = constraintObject;
 
         table.constraints.push(constraintObject);
@@ -166,6 +170,8 @@ export function buildMySQLDatabaseSchmea({
         const constraint =
             constraintLookup[
                 constraintColumn.TABLE_SCHEMA +
+                    '.' +
+                    constraintColumn.TABLE_NAME +
                     '.' +
                     constraintColumn.CONSTRAINT_NAME
             ];

--- a/src/connections/sqlite/base.ts
+++ b/src/connections/sqlite/base.ts
@@ -86,6 +86,25 @@ FROM
             }
         }
 
+        // Building primary key constraint
+        Object.values(tableLookup).forEach((table) => {
+            const primaryKeyColumns = table.columns
+                .filter((column) => column.definition.primaryKey)
+                .map((column) => column.name);
+
+            if (primaryKeyColumns.length) {
+                table.constraints.push({
+                    name: `pk_${table.name}`,
+                    schema: 'main',
+                    tableName: table.name,
+                    type: 'PRIMARY KEY',
+                    columns: primaryKeyColumns.map((columnName) => ({
+                        columnName,
+                    })),
+                });
+            }
+        });
+
         // Sqlite default schema is "main", since we don't support
         // ATTACH, we don't need to worry about other schemas
         return {

--- a/src/query-builder/dialects/bigquery.ts
+++ b/src/query-builder/dialects/bigquery.ts
@@ -1,5 +1,7 @@
 import { MySQLDialect } from './mysql';
 export class BigQueryDialect extends MySQLDialect {
+    protected ALWAY_NO_ENFORCED_CONSTRAINT = true;
+
     escapeId(identifier: string): string {
         return `\`${identifier}\``;
     }

--- a/tests/units/query-builder/postgre.test.ts
+++ b/tests/units/query-builder/postgre.test.ts
@@ -173,12 +173,12 @@ describe('Query Builder - Postgre Dialect', () => {
 
     test('Update query without where condition', () => {
         const { query, parameters } = qb()
-            .update({ last_name: 'Visal', first_name: 'In' })
+            .update({ last_name: 'Visal', banned: null, first_name: 'In' })
             .into('persons')
             .toQuery();
 
         expect(query).toBe(
-            'UPDATE "persons" SET "last_name" = ?, "first_name" = ?'
+            'UPDATE "persons" SET "last_name" = ?, "banned" = NULL, "first_name" = ?'
         );
         expect(parameters).toEqual(['Visal', 'In']);
     });
@@ -191,10 +191,11 @@ describe('Query Builder - Postgre Dialect', () => {
                 id: 123,
                 active: 1,
             })
+            .where('banned', 'IS', null)
             .toQuery();
 
         expect(query).toBe(
-            'UPDATE "persons" SET "last_name" = ?, "first_name" = ? WHERE "id" = ? AND "active" = ?'
+            'UPDATE "persons" SET "last_name" = ?, "first_name" = ? WHERE "id" = ? AND "active" = ? AND "banned" IS NULL'
         );
         expect(parameters).toEqual(['Visal', 'In', 123, 1]);
     });
@@ -211,12 +212,12 @@ describe('Query Builder - Postgre Dialect', () => {
 
     test('Insert data', () => {
         const { query, parameters } = qb()
-            .insert({ last_name: 'Visal', first_name: 'In' })
+            .insert({ last_name: 'Visal', banned: null, first_name: 'In' })
             .into('persons')
             .toQuery();
 
         expect(query).toBe(
-            'INSERT INTO "persons"("last_name", "first_name") VALUES(?, ?)'
+            'INSERT INTO "persons"("last_name", "banned", "first_name") VALUES(?, NULL, ?)'
         );
         expect(parameters).toEqual(['Visal', 'In']);
     });


### PR DESCRIPTION
This PR fix four things:
- Auto casting the value based on column type
- Detect the primary key constraint
- Allow binding NULL value
- Improve the speed of getting schema