### PR TITLE
support raw based holder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@outerbase/sdk",
-    "version": "2.0.0-rc.2",
+    "version": "2.0.0-rc.3",
     "description": "",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/src/connections/bigquery.ts
+++ b/src/connections/bigquery.ts
@@ -204,7 +204,7 @@ export class BigQueryConnection extends SqlConnection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         try {

--- a/src/connections/index.ts
+++ b/src/connections/index.ts
@@ -32,7 +32,10 @@ export abstract class Connection {
 
     // Retrieve metadata about the database, useful for introspection.
     abstract fetchDatabaseSchema(): Promise<Database>;
-    abstract raw(query: string): Promise<QueryResult>;
+    abstract raw(
+        query: string,
+        params?: Record<string, unknown> | unknown[]
+    ): Promise<QueryResult>;
     abstract testConnection(): Promise<{ error?: string }>;
 
     // Connection common operations that will be used by Outerbase

--- a/src/connections/motherduck.ts
+++ b/src/connections/motherduck.ts
@@ -51,7 +51,7 @@ export class DuckDBConnection extends PostgreBaseConnection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         const connection = this.connection;

--- a/src/connections/mysql.ts
+++ b/src/connections/mysql.ts
@@ -225,7 +225,7 @@ export class MySQLConnection extends SqlConnection {
         return super.mapDataType(dataType);
     }
 
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         try {

--- a/src/connections/postgre/postgresql.ts
+++ b/src/connections/postgre/postgresql.ts
@@ -27,7 +27,7 @@ export class PostgreSQLConnection extends PostgreBaseConnection {
         await this.client.end();
     }
 
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         try {

--- a/src/connections/postgre/postgresql.ts
+++ b/src/connections/postgre/postgresql.ts
@@ -3,22 +3,16 @@ import { QueryResult } from '..';
 import { Query } from '../../query';
 import { AbstractDialect } from './../../query-builder';
 import { PostgresDialect } from './../../query-builder/dialects/postgres';
-import { QueryType } from './../../query-params';
 import {
     createErrorResult,
     transformArrayBasedResult,
 } from './../../utils/transformer';
 import { PostgreBaseConnection } from './base';
 
-function replacePlaceholders(query: string): string {
-    let index = 1;
-    return query.replace(/\?/g, () => `$${index++}`);
-}
-
 export class PostgreSQLConnection extends PostgreBaseConnection {
     client: Client;
     dialect: AbstractDialect = new PostgresDialect();
-    queryType: QueryType = QueryType.positional;
+    protected numberedPlaceholder = true;
 
     constructor(pgClient: any) {
         super();
@@ -38,10 +32,7 @@ export class PostgreSQLConnection extends PostgreBaseConnection {
     ): Promise<QueryResult<T>> {
         try {
             const { rows, fields } = await this.client.query({
-                text:
-                    query.parameters?.length === 0
-                        ? query.query
-                        : replacePlaceholders(query.query),
+                text: query.query,
                 rowMode: 'array',
                 values: query.parameters as unknown[],
             });

--- a/src/connections/snowflake/snowflake.ts
+++ b/src/connections/snowflake/snowflake.ts
@@ -175,7 +175,7 @@ export class SnowflakeConnection extends PostgreBaseConnection {
         );
     }
 
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         try {

--- a/src/connections/sql-base.ts
+++ b/src/connections/sql-base.ts
@@ -67,7 +67,11 @@ export abstract class SqlConnection extends Connection {
         }
 
         // Named placeholder
-        const { query: newQuery, bindings } = namedPlaceholder(query, params!);
+        const { query: newQuery, bindings } = namedPlaceholder(
+            query,
+            params!,
+            this.numberedPlaceholder
+        );
         return await this.internalQuery({
             query: newQuery,
             parameters: bindings,

--- a/src/connections/sql-base.ts
+++ b/src/connections/sql-base.ts
@@ -47,7 +47,7 @@ export abstract class SqlConnection extends Connection {
         query: string,
         params?: Record<string, unknown> | unknown[]
     ): Promise<QueryResult> {
-        if (!params) return await this.query({ query });
+        if (!params) return await this.internalQuery({ query });
 
         // Positional placeholder
         if (Array.isArray(params)) {
@@ -57,13 +57,13 @@ export abstract class SqlConnection extends Connection {
                     params
                 );
 
-                return await this.query({
+                return await this.internalQuery({
                     query: newQuery,
                     parameters: bindings,
                 });
             }
 
-            return await this.query({ query, parameters: params });
+            return await this.internalQuery({ query, parameters: params });
         }
 
         // Named placeholder

--- a/src/connections/sqlite/cloudflare.ts
+++ b/src/connections/sqlite/cloudflare.ts
@@ -107,7 +107,7 @@ export class CloudflareD1Connection extends SqliteBaseConnection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         if (!this.apiKey) throw new Error('Cloudflare API key is not set');

--- a/src/connections/sqlite/starbase.ts
+++ b/src/connections/sqlite/starbase.ts
@@ -90,7 +90,7 @@ export class StarbaseConnection extends SqliteBaseConnection {
      * @param parameters - An object containing the parameters to be used in the query.
      * @returns Promise<{ data: any, error: Error | null }>
      */
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         if (!this.url) throw new Error('Starbase URL is not set');

--- a/src/connections/sqlite/turso.ts
+++ b/src/connections/sqlite/turso.ts
@@ -16,7 +16,7 @@ export class TursoConnection extends SqliteBaseConnection {
         this.client = client;
     }
 
-    async query<T = Record<string, unknown>>(
+    async internalQuery<T = Record<string, unknown>>(
         query: Query
     ): Promise<QueryResult<T>> {
         try {

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -82,6 +82,13 @@ export function namedPlaceholder(
 
     const [sqlFragments, placeholders] = parts;
 
+    // If placeholders contains any number, then it's a mix of named and numbered placeholders
+    if (placeholders.some((p) => typeof p === 'number')) {
+        throw new Error(
+            'Mixing named and positional placeholder should throw error'
+        );
+    }
+
     for (let i = 0; i < sqlFragments.length; i++) {
         newQuery += sqlFragments[i];
 
@@ -92,6 +99,11 @@ export function namedPlaceholder(
                 newQuery += `$${i + 1}`;
             } else {
                 newQuery += `?`;
+            }
+
+            const placeholderValue = params[key];
+            if (placeholderValue === undefined) {
+                throw new Error(`Missing value for placeholder ${key}`);
             }
 
             bindings.push(params[key]);
@@ -118,6 +130,19 @@ export function toNumberedPlaceholders(
     let newQuery = '';
 
     const [sqlFragments, placeholders] = parts;
+
+    if (placeholders.length !== params.length) {
+        throw new Error(
+            'Number of positional placeholder should match with the number of values'
+        );
+    }
+
+    // Mixing named and numbered placeholders should throw error
+    if (placeholders.some((p) => typeof p === 'string')) {
+        throw new Error(
+            'Mixing named and positional placeholder should throw error'
+        );
+    }
 
     for (let i = 0; i < sqlFragments.length; i++) {
         newQuery += sqlFragments[i];

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -28,7 +28,6 @@ function parse(query: string): [string] | [string[], (string | number)[]] {
         do {
             for (i = curpos, end = ppos.index; i < end; ++i) {
                 let chr = query.charCodeAt(i);
-                console.log(i, query[i], inQuote, qchr);
                 if (chr === BSLASH) escape = !escape;
                 else {
                     if (escape) {
@@ -90,7 +89,7 @@ export function namedPlaceholder(
             const key = placeholders[i];
 
             if (numbered) {
-                newQuery += `$${key}`;
+                newQuery += `$${i + 1}`;
             } else {
                 newQuery += `?`;
             }

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -1,0 +1,133 @@
+const RE_PARAM = /(?:\?)|(?::(\d+|(?:[a-zA-Z][a-zA-Z0-9_]*)))/g,
+    DQUOTE = 34,
+    SQUOTE = 39,
+    BSLASH = 92;
+
+/**
+ * This code is based on https://github.com/mscdex/node-mariasql/blob/master/lib/Client.js#L296-L420
+ * License: https://github.com/mscdex/node-mariasql/blob/master/LICENSE
+ *
+ * @param query
+ * @returns
+ */
+function parse(query: string): [string] | [string[], (string | number)[]] {
+    let ppos = RE_PARAM.exec(query);
+    let curpos = 0;
+    let start = 0;
+    let end;
+    const parts = [];
+    let inQuote = false;
+    let escape = false;
+    let qchr;
+    const tokens = [];
+    let qcnt = 0;
+    let lastTokenEndPos = 0;
+    let i;
+
+    if (ppos) {
+        do {
+            for (i = curpos, end = ppos.index; i < end; ++i) {
+                let chr = query.charCodeAt(i);
+                console.log(i, query[i], inQuote, qchr);
+                if (chr === BSLASH) escape = !escape;
+                else {
+                    if (escape) {
+                        escape = false;
+                        continue;
+                    }
+                    if (inQuote && chr === qchr) {
+                        if (query.charCodeAt(i + 1) === qchr) {
+                            // quote escaped via "" or ''
+                            ++i;
+                            continue;
+                        }
+                        inQuote = false;
+                    } else if (!inQuote && (chr === DQUOTE || chr === SQUOTE)) {
+                        inQuote = true;
+                        qchr = chr;
+                    }
+                }
+            }
+            if (!inQuote) {
+                parts.push(query.substring(start, end));
+                tokens.push(ppos[0].length === 1 ? qcnt++ : ppos[1]);
+                start = end + ppos[0].length;
+                lastTokenEndPos = start;
+            }
+            curpos = end + ppos[0].length;
+        } while ((ppos = RE_PARAM.exec(query)));
+
+        if (tokens.length) {
+            if (curpos < query.length) {
+                parts.push(query.substring(lastTokenEndPos));
+            }
+            return [parts, tokens];
+        }
+    }
+    return [query];
+}
+
+export function namedPlaceholder(
+    query: string,
+    params: Record<string, unknown>,
+    numbered = false
+): { query: string; bindings: unknown[] } {
+    const parts = parse(query);
+
+    if (parts.length === 1) {
+        return { query, bindings: [] };
+    }
+
+    const bindings = [];
+    let newQuery = '';
+
+    const [sqlFragments, placeholders] = parts;
+
+    for (let i = 0; i < sqlFragments.length; i++) {
+        newQuery += sqlFragments[i];
+
+        if (i < placeholders.length) {
+            const key = placeholders[i];
+
+            if (numbered) {
+                newQuery += `$${key}`;
+            } else {
+                newQuery += `?`;
+            }
+
+            bindings.push(params[key]);
+        }
+    }
+
+    return { query: newQuery, bindings };
+}
+
+export function toNumberedPlaceholders(
+    query: string,
+    params: unknown[]
+): {
+    query: string;
+    bindings: unknown[];
+} {
+    const parts = parse(query);
+
+    if (parts.length === 1) {
+        return { query, bindings: [] };
+    }
+
+    const bindings = [];
+    let newQuery = '';
+
+    const [sqlFragments, placeholders] = parts;
+
+    for (let i = 0; i < sqlFragments.length; i++) {
+        newQuery += sqlFragments[i];
+
+        if (i < placeholders.length) {
+            newQuery += `$${i + 1}`;
+            bindings.push(params[i]);
+        }
+    }
+
+    return { query: newQuery, bindings };
+}

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -37,7 +37,7 @@ function cleanup(data: Record<string, unknown>[]) {
 
 describe('Database Connection', () => {
     test('Support named parameters', async () => {
-        if (process.env.CONNECTION_TYPE === 'mongo') return;
+        if (process.env.CONNECTION_TYPE === 'mongodb') return;
 
         const sql =
             process.env.CONNECTION_TYPE === 'mysql'

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -53,7 +53,7 @@ describe('Database Connection', () => {
     });
 
     test('Support positional placeholder', async () => {
-        if (process.env.CONNECTION_TYPE === 'mongo') return;
+        if (process.env.CONNECTION_TYPE === 'mongodb') return;
 
         const sql =
             process.env.CONNECTION_TYPE === 'mysql'

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -36,6 +36,34 @@ function cleanup(data: Record<string, unknown>[]) {
 }
 
 describe('Database Connection', () => {
+    test('Support named parameters', async () => {
+        if (process.env.CONNECTION_TYPE === 'mongo') return;
+
+        const sql =
+            process.env.CONNECTION_TYPE === 'mysql'
+                ? 'SELECT CONCAT(:hello, :world) AS testing_word'
+                : 'SELECT (:hello || :world) AS testing_word';
+
+        const { data } = await db.raw(sql, {
+            hello: 'hello ',
+            world: 'world',
+        });
+
+        expect(data).toEqual([{ testing_word: 'hello world' }]);
+    });
+
+    test('Support positional placeholder', async () => {
+        if (process.env.CONNECTION_TYPE === 'mongo') return;
+
+        const sql =
+            process.env.CONNECTION_TYPE === 'mysql'
+                ? 'SELECT CONCAT(?, ?) AS testing_word'
+                : 'SELECT (? || ?) AS testing_word';
+
+        const { data } = await db.raw(sql, ['hello ', 'world']);
+        expect(data).toEqual([{ testing_word: 'hello world' }]);
+    });
+
     test('Create table', async () => {
         const { error: createTableTeamError } = await db.createTable(
             DEFAULT_SCHEMA,

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -41,15 +41,15 @@ describe('Database Connection', () => {
 
         const sql =
             process.env.CONNECTION_TYPE === 'mysql'
-                ? 'SELECT CONCAT(:hello, :world) AS testing_word'
-                : 'SELECT (:hello || :world) AS testing_word';
+                ? 'SELECT CONCAT(:hello, :world) AS TESTING_WORD'
+                : 'SELECT (:hello || :world) AS TESTING_WORD';
 
         const { data } = await db.raw(sql, {
             hello: 'hello ',
             world: 'world',
         });
 
-        expect(data).toEqual([{ testing_word: 'hello world' }]);
+        expect(data).toEqual([{ TESTING_WORD: 'hello world' }]);
     });
 
     test('Support positional placeholder', async () => {

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -65,7 +65,12 @@ describe('Database Connection', () => {
                 : 'SELECT (? || ?) AS testing_word';
 
         const { data } = await db.raw(sql, ['hello ', 'world']);
-        expect(data).toEqual([{ testing_word: 'hello world' }]);
+
+        if (process.env.CONNECTION_TYPE === 'snowflake') {
+            expect(data).toEqual([{ TESTING_WORD: 'hello world' }]);
+        } else {
+            expect(data).toEqual([{ testing_word: 'hello world' }]);
+        }
     });
 
     test('Create table', async () => {

--- a/tests/connections/connection.test.ts
+++ b/tests/connections/connection.test.ts
@@ -41,15 +41,19 @@ describe('Database Connection', () => {
 
         const sql =
             process.env.CONNECTION_TYPE === 'mysql'
-                ? 'SELECT CONCAT(:hello, :world) AS TESTING_WORD'
-                : 'SELECT (:hello || :world) AS TESTING_WORD';
+                ? 'SELECT CONCAT(:hello, :world) AS testing_word'
+                : 'SELECT (:hello || :world) AS testing_word';
 
         const { data } = await db.raw(sql, {
             hello: 'hello ',
             world: 'world',
         });
 
-        expect(data).toEqual([{ TESTING_WORD: 'hello world' }]);
+        if (process.env.CONNECTION_TYPE === 'snowflake') {
+            expect(data).toEqual([{ TESTING_WORD: 'hello world' }]);
+        } else {
+            expect(data).toEqual([{ testing_word: 'hello world' }]);
+        }
     });
 
     test('Support positional placeholder', async () => {

--- a/tests/units/placeholder.test.ts
+++ b/tests/units/placeholder.test.ts
@@ -60,6 +60,37 @@ test('Named placeholder to number placeholder with string', () => {
     });
 });
 
+test('Named placeholder with missing value should throw an error', () => {
+    expect(() =>
+        namedPlaceholder('SELECT * FROM users WHERE id = :id AND age > :age', {
+            id: 1,
+        })
+    ).toThrow();
+});
+
+test('Number of positional placeholder should match with the number of values', () => {
+    expect(() =>
+        toNumberedPlaceholders('SELECT * FROM users WHERE id = ? AND age > ?', [
+            1,
+        ])
+    ).toThrow();
+});
+
+test('Mixing named and positional placeholder should throw error', () => {
+    expect(() =>
+        namedPlaceholder('SELECT * FROM users WHERE id = :id AND age > ?', {
+            id: 1,
+        })
+    ).toThrow();
+
+    expect(() => {
+        toNumberedPlaceholders(
+            `SELECT * FROM users WHERE id = ? AND age > :age`,
+            [1, 30]
+        );
+    }).toThrow();
+});
+
 test('Convert positional placeholder to numbered placeholder', () => {
     expect(
         toNumberedPlaceholders(

--- a/tests/units/placeholder.test.ts
+++ b/tests/units/placeholder.test.ts
@@ -1,0 +1,73 @@
+import {
+    namedPlaceholder,
+    toNumberedPlaceholders,
+} from './../../src/utils/placeholder';
+
+test('Positional placeholder', () => {
+    expect(
+        namedPlaceholder('SELECT * FROM users WHERE id = :id AND age > :age', {
+            id: 1,
+            age: 50,
+        })
+    ).toEqual({
+        query: 'SELECT * FROM users WHERE id = ? AND age > ?',
+        bindings: [1, 50],
+    });
+});
+
+test('Positional placeholder inside the string should be ignored', () => {
+    expect(
+        namedPlaceholder(
+            'SELECT * FROM users WHERE name = :name AND email = ":email"',
+            {
+                name: 'John',
+            }
+        )
+    ).toEqual({
+        query: 'SELECT * FROM users WHERE name = ? AND email = ":email"',
+        bindings: ['John'],
+    });
+});
+
+test('Named placeholder to number placeholder', () => {
+    expect(
+        namedPlaceholder(
+            'SELECT * FROM users WHERE id = :id AND age > :age',
+            {
+                id: 1,
+                age: 30,
+            },
+            true
+        )
+    ).toEqual({
+        query: 'SELECT * FROM users WHERE id = $1 AND age > $2',
+        bindings: [1, 30],
+    });
+});
+
+test('Named placeholder to number placeholder with string', () => {
+    expect(
+        namedPlaceholder(
+            'SELECT * FROM users WHERE id = :id AND email = ":email"',
+            {
+                id: 1,
+            },
+            true
+        )
+    ).toEqual({
+        query: 'SELECT * FROM users WHERE id = $1 AND email = ":email"',
+        bindings: [1],
+    });
+});
+
+test('Convert positional placeholder to numbered placeholder', () => {
+    expect(
+        toNumberedPlaceholders(
+            `SELECT * FROM users WHERE id = ? AND email = '?' AND name = 'Outer""base' AND age > ?`,
+            [1, 30]
+        )
+    ).toEqual({
+        query: `SELECT * FROM users WHERE id = $1 AND email = '?' AND name = 'Outer""base' AND age > $2`,
+        bindings: [1, 30],
+    });
+});


### PR DESCRIPTION
Add the support for positional placeholder and named placeholder. You can now use

```typescript
connection.raw("SELECT * FROM tbl WHERE id = ?", [1]);
```

Or 

```typescript
connection.raw("SELECT * FROM tbl WHERE id = :id", { id: 1 });
```



## Test Case

```
  √ Positional placeholder (6 ms)
  √ Positional placeholder inside the string should be ignored
  √ Named placeholder to number placeholder
  √ Named placeholder to number placeholder with string (1 ms) 
  √ Named placeholder with missing value should throw an error (11 ms)
  √ Number of positional placeholder should match with the number of values (1 ms)      
  √ Mixing named and positional placeholder should throw error (1 ms)
  √ Convert positional placeholder to numbered placeholder (1 ms) 
```

**Connection Test Case**
```
  √ Support named parameters
  √ Support positional placeholder
```